### PR TITLE
Force 'records' argument type to list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,5 +8,5 @@ resource "aws_route53_record" "this" {
   name    = "${var.name}"
   type    = "${var.type}"
   ttl     = "${var.ttl}"
-  records = "${split(",", var.ip)}"
+  records = ["${split(",", var.ip)}"]
 }


### PR DESCRIPTION
Latest terraform versions are forced to check input types and faults with error:
```
Error: module.implementation.module.route53-record.aws_route53_record.this: records: should be a list
```